### PR TITLE
Potential fix for code scanning alert no. 6: Incomplete regular expression for hostnames

### DIFF
--- a/itgdb_site/utils/url_fetch.py
+++ b/itgdb_site/utils/url_fetch.py
@@ -45,7 +45,7 @@ def fetch_from_url(url: str) -> str:
         return _fetch_from_sm_online(url)
     
     # fetch from dropbox
-    elif re.match('https?://www.dropbox.com/', url):
+    elif re.match('https?://www\.dropbox\.com/', url):
         # modify URL to so it can be fetched from directly
         url = url.replace('dl=0', 'dl=1')
     


### PR DESCRIPTION
Potential fix for [https://github.com/ScottBrenner/itgdb/security/code-scanning/6](https://github.com/ScottBrenner/itgdb/security/code-scanning/6)

To fix the issue, the `.` in the regular expression should be escaped to ensure it matches a literal dot rather than any character. This can be done by replacing `.` with `\.` in the regex. Specifically, the regex `https?://www.dropbox.com/` should be updated to `https?://www\.dropbox\.com/`. This change ensures that only URLs with the exact domain `www.dropbox.com` are matched.

The fix will be applied to the regex on line 48 of the `fetch_from_url` function in the file `itgdb_site/utils/url_fetch.py`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
